### PR TITLE
Adding Digital IO Functionality to Keithley 2600 Series Driver

### DIFF
--- a/pymeasure/instruments/keithley/keithley2600.py
+++ b/pymeasure/instruments/keithley/keithley2600.py
@@ -67,7 +67,7 @@ class Keithley2600(Instrument):
         code, message = self.error
         while code != 0:
             t = time.time()
-            log.info("Keithley 2600 reported error: %d, %s" % (code, message))
+            log.info(f"Keithley 2600 reported error: {code}, {message}")
             code, message = self.error
             if (time.time() - t) > 10:
                 log.warning("Timed out for Keithley 2600 error retrieval.")
@@ -121,11 +121,7 @@ class Channel:
 
     def binary_values(self, cmd, header_bytes=0, dtype=np.float32):
         return self.instrument.binary_values(
-            "print(smu%s.%s)"
-            % (
-                self.channel,
-                cmd,
-            ),
+            f"print(smu{self.channel}.{cmd})",
             header_bytes,
             dtype,
         )
@@ -262,9 +258,9 @@ class Channel:
         :param voltage: Upper limit of voltage in Volts, from -200 V to 200 V
         :param auto_range: Enables auto_range if True, else uses the set voltage
         """
-        log.info("%s is measuring voltage." % self.channel)
+        log.info(f"{self.channel} is measuring voltage.")
         self.write("measure.v()")
-        self.write("measure.nplc=%f" % nplc)
+        self.write(f"measure.nplc={nplc:f}")
         if auto_range:
             self.write("measure.autorangev=1")
         else:
@@ -277,9 +273,9 @@ class Channel:
         :param current: Upper limit of current in Amps, from -1.5 A to 1.5 A
         :param auto_range: Enables auto_range if True, else uses the set current
         """
-        log.info("%s is measuring current." % self.channel)
+        log.info(f"{self.channel} is measuring current.")
         self.write("measure.i()")
-        self.write("measure.nplc=%f" % nplc)
+        self.write(f"measure.nplc={nplc:f}")
         if auto_range:
             self.write("measure.autorangei=1")
         else:
@@ -301,7 +297,7 @@ class Channel:
                                    :attr:`~.Keithley2600.compliance_voltage`
         :param current_range: A :attr:`~.Keithley2600.current_range` value or None
         """
-        log.info("%s is sourcing current." % self.channel)
+        log.info(f"{self.channel} is sourcing current.")
         self.source_mode = "current"
         if current_range is None:
             self.auto_range_source()
@@ -318,7 +314,7 @@ class Channel:
                                    :attr:`~.Keithley2600.compliance_current`
         :param voltage_range: A :attr:`~.Keithley2600.voltage_range` value or None
         """
-        log.info("%s is sourcing voltage." % self.channel)
+        log.info(f"{self.channel} is sourcing voltage.")
         self.source_mode = "voltage"
         if voltage_range is None:
             self.auto_range_source()
@@ -352,7 +348,7 @@ class Channel:
     def shutdown(self):
         """Ensures that the current or voltage is turned to zero
         and disables the output."""
-        log.info("Shutting down channel %s." % self.channel)
+        log.info(f"Shutting down channel {self.channel}.")
         if self.source_mode == "current":
             self.ramp_to_current(0.0)
         else:

--- a/pymeasure/instruments/keithley/keithley2600.py
+++ b/pymeasure/instruments/keithley/keithley2600.py
@@ -97,7 +97,8 @@ class Keithley2600(Instrument):
     def id(self):
         """Requests and returns the identification of the instrument."""
         return self.ask(
-            "print([[Keithley Instruments, Model]]..localnode.model..[[,]]..localnode.serialno.. [[, ]]..localnode.revision)"
+            "print([[Keithley Instruments, Model]]..localnode.model..[[,]]..\
+            localnode.serialno.. [[, ]]..localnode.revision)"
         ).strip()
 
 

--- a/pymeasure/instruments/keithley/keithley2600.py
+++ b/pymeasure/instruments/keithley/keithley2600.py
@@ -34,7 +34,9 @@ log.addHandler(logging.NullHandler())
 
 class Keithley2600(Instrument):
     """Represents the Keithley 2600 series (channel A and B) SourceMeter"""
-
+    
+    number_of_pins = 14
+    
     def __init__(self, adapter, **kwargs):
         super().__init__(
             adapter,
@@ -43,6 +45,10 @@ class Keithley2600(Instrument):
         )
         self.ChA = Channel(self, 'a')
         self.ChB = Channel(self, 'b')
+        
+        self.dio_pins = []
+        for i in range(1, Keithley2600.number_of_pins + 1):
+            self.dio_pins[i] = DigitalIOPin(self, [i])
 
     @property
     def error(self):
@@ -72,7 +78,55 @@ class Keithley2600(Instrument):
             code, message = self.error
             if (time.time() - t) > 10:
                 log.warning("Timed out for Keithley 2600 error retrieval.")
+                
+class DigitalIOPin:
+    
+    def __init__(self, instrument, pin_number):
+        self.instrument = instrument
+        self.pin_number = pin_number
 
+    def ask(self, cmd):
+        return self.instrument.ask(f'print(digio.trigger[{self.pin_number}].{cmd})')
+
+    def write(self, cmd):
+        self.instrument.write(f'digio.trigger.[{self.pin_number}].{cmd}')
+        
+    def check_errors(self):
+        return self.instrument.check_errors()
+        
+    def assert_trigger(self):
+        """This function asserts a trigger pulse on one of the digital I/O lines.
+        """
+        log.info("Asserting a trigger pulse on pin number %s." % self.pin_number)
+        self.write('assert()')
+        self.check_errors()
+        
+    def clear_trigger(self):
+        """This function clears the trigger event on a digital I/O line.
+        """
+        log.info("Clearing trigger on pin number %s." % self.pin_number)
+        self.write('clear()')
+        self.check_errors()
+        
+    def get_event_id(self):
+        """This function gets the mode in which the trigger event detector and
+        the output trigger generator operate on the
+        given trigger line. 
+        """
+        id = self.ask('EVENT_ID')
+        self.check_errors()
+        return int(id)
+        
+    trigger_mode = Instrument.control(
+        'mode', 'mode=%d',
+        """Property controlling the mode in which the trigger event detector and 
+        the output trigger generator operate on the given trigger line.
+        """,
+        validator=strict_discrete_set,
+        values={'TRIG_BYPASS': 0, 'TRIG_FALLING': 1, 'TRIG_RISING': 2, 'TRIG_EITHER': 3, 'TRIG_SYNCHRONOUSA': 4, 
+                'TRIG_SYNCHRONOUS': 5, 'TRIG_SYNCHRONOUSM': 6, 'TRIG_RISINGA': 7, 'TRIG_RISINGM': 8},
+        map_values=True
+    )
 
 class Channel:
 

--- a/pymeasure/instruments/keithley/keithley2600.py
+++ b/pymeasure/instruments/keithley/keithley2600.py
@@ -23,9 +23,11 @@
 
 import logging
 import time
+
 import numpy as np
+
 from pymeasure.instruments import Instrument
-from pymeasure.instruments.validators import truncated_range, strict_discrete_set
+from pymeasure.instruments.validators import strict_discrete_set, truncated_range
 
 # Setup logging
 log = logging.getLogger(__name__)
@@ -34,38 +36,34 @@ log.addHandler(logging.NullHandler())
 
 class Keithley2600(Instrument):
     """Represents the Keithley 2600 series (channel A and B) SourceMeter"""
-    
+
     def __init__(self, adapter, **kwargs):
         super().__init__(
-            adapter,
-            "Keithley 2600 SourceMeter",
-            includeSCPI=False,
-            **kwargs
+            adapter, "Keithley 2600 SourceMeter", includeSCPI=False, **kwargs
         )
-        self.ChA = Channel(self, 'a')
-        self.ChB = Channel(self, 'b')
-    
+        self.ChA = Channel(self, "a")
+        self.ChB = Channel(self, "b")
+
     @property
     def error(self):
-        """ Returns a tuple of an error code and message from a
-        single error. """
-        err = self.ask('print(errorqueue.next())')
-        err = err.split('\t')
+        """Returns a tuple of an error code and message from a
+        single error."""
+        err = self.ask("print(errorqueue.next())")
+        err = err.split("\t")
         # Keithley Instruments Inc. sometimes on startup
         # if tab delimitated message is greater than one, grab first two as code, message
         # otherwise, assign code & message to returned error
         if len(err) > 1:
             err = (int(float(err[0])), err[1])
             code = err[0]
-            message = err[1].replace('"', '')
+            message = err[1].replace('"', "")
         else:
             code = message = err[0]
         log.info(f"ERROR {str(code)},{str(message)} - len {str(len(err))}")
         return (code, message)
 
     def check_errors(self):
-        """ Logs any system errors reported by the instrument.
-        """
+        """Logs any system errors reported by the instrument."""
         code, message = self.error
         while code != 0:
             t = time.time()
@@ -73,145 +71,184 @@ class Keithley2600(Instrument):
             code, message = self.error
             if (time.time() - t) > 10:
                 log.warning("Timed out for Keithley 2600 error retrieval.")
-                
+
+    def clear(self):
+        """Clears the instrument status byte"""
+        self.write("status.reset()")
+
+    def reset(self):
+        """Resets the instrument."""
+        self.write("*reset()")
+
+    @property
+    def complete(self):
+        """This property allows synchronization between a controller and a device. The Operation Complete
+        query places an ASCII character 1 into the device's Output Queue when all pending
+        selected device operations have been finished.
+        """
+        return self.ask("waitcomplete() print([[1]])").strip()
+
+    @property
+    def status(self):
+        """Requests and returns the status byte and Master Summary Status bit."""
+        return self.ask("print(tostring(status.condition))").strip()
+
+    @property
+    def id(self):
+        """Requests and returns the identification of the instrument."""
+        return self.ask(
+            "print([[Keithley Instruments, Model]]..localnode.model..[[,]]..localnode.serialno.. [[, ]]..localnode.revision)"
+        ).strip()
+
 
 class Channel:
-
     def __init__(self, instrument, channel):
         self.instrument = instrument
         self.channel = channel
 
     def ask(self, cmd):
-        return float(self.instrument.ask(f'print(smu{self.channel}.{cmd})'))
+        return float(self.instrument.ask(f"print(smu{self.channel}.{cmd})"))
 
     def write(self, cmd):
-        self.instrument.write(f'smu{self.channel}.{cmd}')
+        self.instrument.write(f"smu{self.channel}.{cmd}")
 
     def values(self, cmd, **kwargs):
-        """ Reads a set of values from the instrument through the adapter,
+        """Reads a set of values from the instrument through the adapter,
         passing on any key-word arguments.
         """
-        return self.instrument.values(f'print(smu{self.channel}.{cmd})')
+        return self.instrument.values(f"print(smu{self.channel}.{cmd})")
 
     def binary_values(self, cmd, header_bytes=0, dtype=np.float32):
-        return self.instrument.binary_values('print(smu%s.%s)' %
-                                             (self.channel, cmd,), header_bytes, dtype)
+        return self.instrument.binary_values(
+            "print(smu%s.%s)"
+            % (
+                self.channel,
+                cmd,
+            ),
+            header_bytes,
+            dtype,
+        )
 
     def check_errors(self):
         return self.instrument.check_errors()
 
     source_output = Instrument.control(
-        'source.output', 'source.output=%d',
+        "source.output",
+        "source.output=%d",
         """Property controlling the channel output state (ON of OFF)
         """,
         validator=strict_discrete_set,
-        values={'OFF': 0, 'ON': 1},
-        map_values=True
+        values={"OFF": 0, "ON": 1},
+        map_values=True,
     )
 
     source_mode = Instrument.control(
-        'source.func', 'source.func=%d',
+        "source.func",
+        "source.func=%d",
         """Property controlling the channel soource function (Voltage or Current)
         """,
         validator=strict_discrete_set,
-        values={'voltage': 1, 'current': 0},
-        map_values=True
+        values={"voltage": 1, "current": 0},
+        map_values=True,
     )
 
     measure_nplc = Instrument.control(
-        'measure.nplc', 'measure.nplc=%f',
+        "measure.nplc",
+        "measure.nplc=%f",
         """ Property controlling the nplc value """,
         validator=truncated_range,
         values=[0.001, 25],
-        map_values=True
+        map_values=True,
     )
 
     ###############
     # Current (A) #
     ###############
-    current = Instrument.measurement(
-        'measure.i()',
-        """ Reads the current in Amps """
-    )
+    current = Instrument.measurement("measure.i()", """ Reads the current in Amps """)
 
     source_current = Instrument.control(
-        'source.leveli', 'source.leveli=%f',
+        "source.leveli",
+        "source.leveli=%f",
         """ Property controlling the applied source current """,
         validator=truncated_range,
-        values=[-1.5, 1.5]
+        values=[-1.5, 1.5],
     )
 
     compliance_current = Instrument.control(
-        'source.limiti', 'source.limiti=%f',
+        "source.limiti",
+        "source.limiti=%f",
         """ Property controlling the source compliance current """,
         validator=truncated_range,
-        values=[-1.5, 1.5]
+        values=[-1.5, 1.5],
     )
 
     source_current_range = Instrument.control(
-        'source.rangei', 'source.rangei=%f',
+        "source.rangei",
+        "source.rangei=%f",
         """Property controlling the source current range """,
         validator=truncated_range,
-        values=[-1.5, 1.5]
+        values=[-1.5, 1.5],
     )
 
     current_range = Instrument.control(
-        'measure.rangei', 'measure.rangei=%f',
+        "measure.rangei",
+        "measure.rangei=%f",
         """Property controlling the measurement current range """,
         validator=truncated_range,
-        values=[-1.5, 1.5]
+        values=[-1.5, 1.5],
     )
 
     ###############
     # Voltage (V) #
     ###############
-    voltage = Instrument.measurement(
-        'measure.v()',
-        """ Reads the voltage in Volts """
-    )
+    voltage = Instrument.measurement("measure.v()", """ Reads the voltage in Volts """)
 
     source_voltage = Instrument.control(
-        'source.levelv', 'source.levelv=%f',
+        "source.levelv",
+        "source.levelv=%f",
         """ Property controlling the applied source voltage """,
         validator=truncated_range,
-        values=[-200, 200]
+        values=[-200, 200],
     )
 
     compliance_voltage = Instrument.control(
-        'source.limitv', 'source.limitv=%f',
+        "source.limitv",
+        "source.limitv=%f",
         """ Property controlling the source compliance voltage """,
         validator=truncated_range,
-        values=[-200, 200]
+        values=[-200, 200],
     )
 
     source_voltage_range = Instrument.control(
-        'source.rangev', 'source.rangev=%f',
+        "source.rangev",
+        "source.rangev=%f",
         """Property controlling the source current range """,
         validator=truncated_range,
-        values=[-200, 200]
+        values=[-200, 200],
     )
 
     voltage_range = Instrument.control(
-        'measure.rangev', 'measure.rangev=%f',
+        "measure.rangev",
+        "measure.rangev=%f",
         """Property controlling the measurement voltage range """,
         validator=truncated_range,
-        values=[-200, 200]
+        values=[-200, 200],
     )
 
     ####################
     # Resistance (Ohm) #
     ####################
     resistance = Instrument.measurement(
-        'measure.r()',
-        """ Reads the resistance in Ohms """
+        "measure.r()", """ Reads the resistance in Ohms """
     )
 
     wires_mode = Instrument.control(
-        'sense', 'sense=%d',
+        "sense",
+        "sense=%d",
         """Property controlling the resistance measurement mode: 4 wires or 2 wires""",
         validator=strict_discrete_set,
-        values={'4': 1, '2': 0},
-        map_values=True
+        values={"4": 1, "2": 0},
+        map_values=True,
     )
 
     #######################
@@ -219,45 +256,44 @@ class Channel:
     #######################
 
     def measure_voltage(self, nplc=1, voltage=21.0, auto_range=True):
-        """ Configures the measurement of voltage.
+        """Configures the measurement of voltage.
         :param nplc: Number of power line cycles (NPLC) from 0.001 to 25
         :param voltage: Upper limit of voltage in Volts, from -200 V to 200 V
         :param auto_range: Enables auto_range if True, else uses the set voltage
         """
         log.info("%s is measuring voltage." % self.channel)
-        self.write('measure.v()')
-        self.write('measure.nplc=%f' % nplc)
+        self.write("measure.v()")
+        self.write("measure.nplc=%f" % nplc)
         if auto_range:
-            self.write('measure.autorangev=1')
+            self.write("measure.autorangev=1")
         else:
             self.voltage_range = voltage
         self.check_errors()
 
     def measure_current(self, nplc=1, current=1.05e-4, auto_range=True):
-        """ Configures the measurement of current.
+        """Configures the measurement of current.
         :param nplc: Number of power line cycles (NPLC) from 0.001 to 25
         :param current: Upper limit of current in Amps, from -1.5 A to 1.5 A
         :param auto_range: Enables auto_range if True, else uses the set current
         """
         log.info("%s is measuring current." % self.channel)
-        self.write('measure.i()')
-        self.write('measure.nplc=%f' % nplc)
+        self.write("measure.i()")
+        self.write("measure.nplc=%f" % nplc)
         if auto_range:
-            self.write('measure.autorangei=1')
+            self.write("measure.autorangei=1")
         else:
             self.current_range = current
         self.check_errors()
 
     def auto_range_source(self):
-        """ Configures the source to use an automatic range.
-        """
-        if self.source_mode == 'current':
-            self.write('source.autorangei=1')
+        """Configures the source to use an automatic range."""
+        if self.source_mode == "current":
+            self.write("source.autorangei=1")
         else:
-            self.write('source.autorangev=1')
+            self.write("source.autorangev=1")
 
     def apply_current(self, current_range=None, compliance_voltage=0.1):
-        """ Configures the instrument to apply a source current, and
+        """Configures the instrument to apply a source current, and
         uses an auto range unless a current range is specified.
         The compliance voltage is also set.
         :param compliance_voltage: A float in the correct range for a
@@ -265,7 +301,7 @@ class Channel:
         :param current_range: A :attr:`~.Keithley2600.current_range` value or None
         """
         log.info("%s is sourcing current." % self.channel)
-        self.source_mode = 'current'
+        self.source_mode = "current"
         if current_range is None:
             self.auto_range_source()
         else:
@@ -273,9 +309,8 @@ class Channel:
         self.compliance_voltage = compliance_voltage
         self.check_errors()
 
-    def apply_voltage(self, voltage_range=None,
-                      compliance_current=0.1):
-        """ Configures the instrument to apply a source voltage, and
+    def apply_voltage(self, voltage_range=None, compliance_current=0.1):
+        """Configures the instrument to apply a source voltage, and
         uses an auto range unless a voltage range is specified.
         The compliance current is also set.
         :param compliance_current: A float in the correct range for a
@@ -283,7 +318,7 @@ class Channel:
         :param voltage_range: A :attr:`~.Keithley2600.voltage_range` value or None
         """
         log.info("%s is sourcing voltage." % self.channel)
-        self.source_mode = 'voltage'
+        self.source_mode = "voltage"
         if voltage_range is None:
             self.auto_range_source()
         else:
@@ -292,33 +327,33 @@ class Channel:
         self.check_errors()
 
     def ramp_to_voltage(self, target_voltage, steps=30, pause=0.1):
-        """ Ramps to a target voltage from the set voltage value over
+        """Ramps to a target voltage from the set voltage value over
         a certain number of linear steps, each separated by a pause duration.
         :param target_voltage: A voltage in Amps
         :param steps: An integer number of steps
-        :param pause: A pause duration in seconds to wait between steps """
+        :param pause: A pause duration in seconds to wait between steps"""
         voltages = np.linspace(self.source_voltage, target_voltage, steps)
         for voltage in voltages:
             self.source_voltage = voltage
             time.sleep(pause)
 
     def ramp_to_current(self, target_current, steps=30, pause=0.1):
-        """ Ramps to a target current from the set current value over
+        """Ramps to a target current from the set current value over
         a certain number of linear steps, each separated by a pause duration.
         :param target_current: A current in Amps
         :param steps: An integer number of steps
-        :param pause: A pause duration in seconds to wait between steps """
+        :param pause: A pause duration in seconds to wait between steps"""
         currents = np.linspace(self.source_current, target_current, steps)
         for current in currents:
             self.source_current = current
             time.sleep(pause)
 
     def shutdown(self):
-        """ Ensures that the current or voltage is turned to zero
-        and disables the output. """
+        """Ensures that the current or voltage is turned to zero
+        and disables the output."""
         log.info("Shutting down channel %s." % self.channel)
-        if self.source_mode == 'current':
+        if self.source_mode == "current":
             self.ramp_to_current(0.0)
         else:
             self.ramp_to_voltage(0.0)
-        self.source_output = 'OFF'
+        self.source_output = "OFF"

--- a/pymeasure/instruments/keithley/keithley2602B.py
+++ b/pymeasure/instruments/keithley/keithley2602B.py
@@ -1,0 +1,111 @@
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.keithley.keithley2600 import Keithley2600
+from pymeasure.instruments.validators import strict_discrete_set
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+class Keithley2602B(Keithley2600):
+    """Represents the Keithley 2602B SourceMeter. This class adds digital I/O 
+    functionality to the Keithley2600 series driver. Note that this driver can
+    be used to control any of the other 2600 series models that support digital
+    I/O (2601B, 2611B, 2612B, 2635B, 2636B).
+    """
+    
+    number_of_pins = 14
+    
+    def __init__(self, adapter, **kwargs):
+        super().__init__(
+            adapter,
+            includeSCPI=False,
+            **kwargs
+        )
+        
+        self.dio_pins = []
+        for i in range(1, Keithley2602B.number_of_pins + 1):
+            self.dio_pins[i] = DigitalIOPin(self, i)
+            
+class DigitalIOPin:
+    
+    def __init__(self, instrument, pin_number):
+        self.instrument = instrument
+        self.pin_number = pin_number
+
+    def ask(self, cmd):
+        return self.instrument.ask(f'print(digio.trigger[{self.pin_number}].{cmd})')
+
+    def write(self, cmd):
+        self.instrument.write(f'digio.trigger.[{self.pin_number}].{cmd}')
+        
+    def check_errors(self):
+        return self.instrument.check_errors()
+        
+    def assert_trigger(self):
+        """This function asserts a trigger pulse on one of the digital I/O lines.
+        """
+        log.info("Asserting a trigger pulse on pin number %s." % self.pin_number)
+        self.write('assert()')
+        self.check_errors()
+        
+    def clear_trigger(self):
+        """This function clears the trigger event on a digital I/O line.
+        """
+        log.info("Clearing trigger on pin number %s." % self.pin_number)
+        self.write('clear()')
+        self.check_errors()
+        
+    def get_event_id(self):
+        """This function gets the mode in which the trigger event detector and
+        the output trigger generator operate on the
+        given trigger line. 
+        """
+        id = self.ask('EVENT_ID')
+        self.check_errors()
+        return int(id)
+    
+    def get_overrun_status(self):
+        """This function gets the event detector overrun status. If this is
+        true, an event was ignored because the event detector was already in the
+        detected state when the event occurred. This is an indication of the
+        state of the event detector built into the line itself. It does not
+        indicate if an overrun occurred in any other part of the trigger model
+        or in any other detector that is monitoring the event."""
+        status = self.ask('EVENT_ID')
+        self.check_errors()
+        return int(id)
+        
+    trigger_mode = Instrument.control(
+        'mode', 'mode=%d',
+        """Property controlling the mode in which the trigger event detector and 
+        the output trigger generator operate on the given trigger line.
+        """,
+        validator=strict_discrete_set,
+        values={'TRIG_BYPASS': 0, 'TRIG_FALLING': 1, 'TRIG_RISING': 2, 'TRIG_EITHER': 3, 'TRIG_SYNCHRONOUSA': 4, 
+                'TRIG_SYNCHRONOUS': 5, 'TRIG_SYNCHRONOUSM': 6, 'TRIG_RISINGA': 7, 'TRIG_RISINGM': 8},
+        map_values=True
+    )
+    

--- a/pymeasure/instruments/keithley/keithley2602B.py
+++ b/pymeasure/instruments/keithley/keithley2602B.py
@@ -52,7 +52,8 @@ class Keithley2602B(Keithley2600):
         """Returns a list of the valid event IDs that can be used to select the event that
         causes a trigger to be asserted on the digital output line. The list can be indexed
         to set a digitial I/O line to assert a trigger given the described conditions. E.g.
-        to set digital line 4 to asser a trigger when the SMU completes a source action on channel A,
+        to set digital line 4 to asser a trigger when the SMU completes a source
+        action on channel A,
         use the following:
 
         .. code-block:: python
@@ -202,9 +203,9 @@ class DigitalIOPin:
     stimulus = Instrument.control(
         "stimulus",
         "stimulus=%s",
-        """Property controlling the event that causes a trigger to be asserted on the digital output line.
-        When setting this property, get the valid event descriptions using the get_trigger_event_description_strings
-        method in the Keithley2602B class.
+        """Property controlling the event that causes a trigger to be asserted on the digital output
+        line.When setting this property, get the valid event descriptions using the
+        get_trigger_event_description_strings method in the Keithley2602B class.
         """,
         validator=strict_discrete_set,
         values=Keithley2602B.get_trigger_event_description_strings(),

--- a/pymeasure/instruments/keithley/keithley2602B.py
+++ b/pymeasure/instruments/keithley/keithley2602B.py
@@ -22,90 +22,191 @@
 #
 
 import logging
+
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.keithley.keithley2600 import Keithley2600
-from pymeasure.instruments.validators import strict_discrete_set
+from pymeasure.instruments.validators import strict_discrete_set, truncated_range
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
+
 class Keithley2602B(Keithley2600):
-    """Represents the Keithley 2602B SourceMeter. This class adds digital I/O 
+    """Represents the Keithley 2602B SourceMeter. This class adds digital I/O
     functionality to the Keithley2600 series driver. Note that this driver can
     be used to control any of the other 2600 series models that support digital
     I/O (2601B, 2611B, 2612B, 2635B, 2636B).
     """
-    
+
     number_of_pins = 14
-    
+
     def __init__(self, adapter, **kwargs):
-        super().__init__(
-            adapter,
-            includeSCPI=False,
-            **kwargs
-        )
-        
+        super().__init__(adapter, includeSCPI=False, **kwargs)
+
         self.dio_pins = []
         for i in range(1, Keithley2602B.number_of_pins + 1):
             self.dio_pins[i] = DigitalIOPin(self, i)
-            
+
+    @staticmethod
+    def get_trigger_event_description_strings():
+        """Returns a list of the valid event IDs that can be used to select the event that
+        causes a trigger to be asserted on the digital output line. The list can be indexed
+        to set a digitial I/O line to assert a trigger given the described conditions. E.g.
+        to set digital line 4 to asser a trigger when the SMU completes a source action on channel A,
+        use the following:
+
+        .. code-block:: python
+
+            #Assume a Keithley2602B object called "smu" has been successully instaniated
+            trigger_event_lists = smu.get_trigger_event_description_strings()
+            smu.dio_pins[3].stimulus = trigger_event_lists[0]
+
+        See page 9-61 of the Reference Manual for more details about the various event
+        descriptions.
+        """
+        event_descriptions = []
+
+        for channel in ["a", "b"]:
+            event_descriptions.append(f"smu{channel}.trigger.SOURCE_COMPLETE_EVENT_ID")
+            event_descriptions.append(f"smu{channel}.trigger.MEASURE_COMPLETE_EVENT_ID")
+            event_descriptions.append(f"smu{channel}.trigger.PULSE_COMPLETE_EVENT_ID")
+            event_descriptions.append(f"smu{channel}.trigger.SWEEP_COMPLETE_EVENT_ID")
+            event_descriptions.append(f"smu{channel}.trigger.IDLE_EVENT_ID")
+
+        return event_descriptions
+
+
 class DigitalIOPin:
-    
     def __init__(self, instrument, pin_number):
         self.instrument = instrument
         self.pin_number = pin_number
 
     def ask(self, cmd):
-        return self.instrument.ask(f'print(digio.trigger[{self.pin_number}].{cmd})')
+        return self.instrument.ask(f"print(digio.trigger[{self.pin_number}].{cmd})")
 
     def write(self, cmd):
-        self.instrument.write(f'digio.trigger.[{self.pin_number}].{cmd}')
-        
+        self.instrument.write(f"digio.trigger.[{self.pin_number}].{cmd}")
+
     def check_errors(self):
         return self.instrument.check_errors()
-        
+
     def assert_trigger(self):
-        """This function asserts a trigger pulse on one of the digital I/O lines.
-        """
-        log.info("Asserting a trigger pulse on pin number %s." % self.pin_number)
-        self.write('assert()')
+        """This method asserts a trigger pulse on one of the digital I/O lines."""
+
+        log.info("Asserting a trigger pulse on pin number %d." % self.pin_number)
+        self.write("assert()")
         self.check_errors()
-        
+
     def clear_trigger(self):
-        """This function clears the trigger event on a digital I/O line.
-        """
-        log.info("Clearing trigger on pin number %s." % self.pin_number)
-        self.write('clear()')
+        """This method clears the trigger event detector on a digital I/O line."""
+
+        log.info("Clearing trigger on pin number %d." % self.pin_number)
+        self.write("clear()")
         self.check_errors()
-        
+
     def get_event_id(self):
-        """This function gets the mode in which the trigger event detector and
-        the output trigger generator operate on the
-        given trigger line. 
+        """This method returns the mode in which the trigger event detector and
+        the output trigger generator operate on the given trigger line. See description
+        of all the possible EVENT_IDs on page 9-57 of the Series 2600B Reference Manual.
         """
-        id = self.ask('EVENT_ID')
+
+        id = self.ask("EVENT_ID")
         self.check_errors()
         return int(id)
-    
+
     def get_overrun_status(self):
-        """This function gets the event detector overrun status. If this is
+        """This method returns the event detector overrun status. If this is
         true, an event was ignored because the event detector was already in the
         detected state when the event occurred. This is an indication of the
         state of the event detector built into the line itself. It does not
         indicate if an overrun occurred in any other part of the trigger model
         or in any other detector that is monitoring the event."""
-        status = self.ask('EVENT_ID')
+
+        response_status = self.ask("overrun")
         self.check_errors()
-        return int(id)
-        
+
+        if response_status == "false":
+            status = False
+        elif response_status == "true":
+            status = True
+        else:
+            status = None
+
+        return status
+
+    def release_trigger(self):
+        """This method releases an indefinite length or latched trigger."""
+
+        log.info("Releasing trigger on pin number %d." % self.pin_number)
+        self.write("release()")
+        self.check_errors()
+
+    def reset_trigger_values(self):
+        """This method resets trigger values to their factory defaults. It
+        sets the mode, pulsewidth, stimulus, and overrun status to factory
+        default settings.
+        """
+
+        log.info(
+            "Resetting trigger values (to factory defaults) on pin number %d."
+            % self.pin_number
+        )
+        self.write("reset()")
+        self.check_errors()
+
+    def wait_for_trigger(self, timeout):
+        """This method waits for a trigger for up to a maximum of the timeout value (in seconds).
+        Returns True if a trigger was detected, false if the timout was reached and no trigger was
+        detected.
+        """
+
+        log.info(
+            "Waiting for trigger for %f on pin number %d." % (timeout, self.pin_number)
+        )
+        self.write("wait(timeout)")
+        self.check_errors()
+
     trigger_mode = Instrument.control(
-        'mode', 'mode=%d',
-        """Property controlling the mode in which the trigger event detector and 
+        "mode",
+        "mode=%d",
+        """Property controlling the mode in which the trigger event detector and
         the output trigger generator operate on the given trigger line.
         """,
         validator=strict_discrete_set,
-        values={'TRIG_BYPASS': 0, 'TRIG_FALLING': 1, 'TRIG_RISING': 2, 'TRIG_EITHER': 3, 'TRIG_SYNCHRONOUSA': 4, 
-                'TRIG_SYNCHRONOUS': 5, 'TRIG_SYNCHRONOUSM': 6, 'TRIG_RISINGA': 7, 'TRIG_RISINGM': 8},
-        map_values=True
+        values={
+            "TRIG_BYPASS": 0,
+            "TRIG_FALLING": 1,
+            "TRIG_RISING": 2,
+            "TRIG_EITHER": 3,
+            "TRIG_SYNCHRONOUSA": 4,
+            "TRIG_SYNCHRONOUS": 5,
+            "TRIG_SYNCHRONOUSM": 6,
+            "TRIG_RISINGA": 7,
+            "TRIG_RISINGM": 8,
+        },
+        map_values=True,
     )
-    
+
+    pulse_width = Instrument.control(
+        "pulsewidth",
+        "pulsewidth=%f",
+        """Property controlling the length of time (in seconds) that the trigger line is asserted
+        for output triggers. Setting the pulse width to zero (0) seconds asserts
+        the trigger indefinitely. To release the trigger line, use release_trigger().
+        """,
+        validator=truncated_range,
+        values=[0, 10],
+        map_values=False,
+    )
+
+    stimulus = Instrument.control(
+        "stimulus",
+        "stimulus=%s",
+        """Property controlling the event that causes a trigger to be asserted on the digital output line.
+        When setting this property, get the valid event descriptions using the get_trigger_event_description_strings
+        method in the Keithley2602B class.
+        """,
+        validator=strict_discrete_set,
+        values=Keithley2602B.get_trigger_event_description_strings(),
+        map_values=False,
+    )


### PR DESCRIPTION
**Description of the Change:**
This PR adds the Keithley2602B driver, which inherits from Keithley2600. The new driver adds digital I/O (hardware triggering) functionality. This PR also adds some compatible common commands to the base Keithley2600 class to overwrite the Instrument classes standard methods (which are based on SCPI commands, the commands for this driver are written in Lua).

Note that I used this same branch to create a PR in the PyMeasure repo: https://github.com/pymeasure/pymeasure/pull/640

I will have at least one more PR for this driver - I will add my unit tests in that PR.

**Version information (please select exactly one):**

- [ ] MAJOR version bump: this PR makes incompatible API changes
- [x] MINOR version bump: this PR adds functionality in a backwards compatible manner
- [ ] PATCH version bump: this PR adds backwards compatible bug fixes